### PR TITLE
Streamline example installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ node_modules
 .node_repl_history
 
 # elm-package generated files
-elm-package.json
 elm-stuff/
 # elm-repl generated files
 repl-temp-*

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.0.0",
+    "summary": "elm-hot-loader example",
+    "repository": "http://github.com/user/project.git",
+    "license": "ISC",
+    "source-directories": [
+        "src"
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "3.0.0 <= v < 4.0.0",
+        "evancz/elm-effects": "2.0.1 <= v < 3.0.0",
+        "evancz/elm-html": "4.0.2 <= v < 5.0.0",
+        "evancz/start-app": "2.0.2 <= v < 3.0.0"
+    },
+    "elm-version": "0.16.0 <= v < 0.17.0"
+}

--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "webpack-dev-server --hot --inline --port 3000",
-    "build": "webpack"
+    "build": "webpack",
+    "postinstall": "elm-package install -y"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
To streamline running the example, include the `elm-package.json` file and add elm package installation as an npm post-install hook.
