### PR TITLE
hmr.js: Remove ES6 feature

### DIFF
--- a/hmr.js
+++ b/hmr.js
@@ -184,7 +184,7 @@ if (module.hot) {
           instances[id] = {
             elm: elm,
             name: name,
-            container,
+            container: container,
             portSubscribes: wrapPorts(elm, {})
           };
 


### PR DESCRIPTION
Small tweak to remove an ES6 form (accidently?) used (object initializer shorthand), so it works in browsers that don't support that.
