### PR TITLE
Replace 'const' with 'var' make Safari work

### DIFF
--- a/hmr.js
+++ b/hmr.js
@@ -107,7 +107,7 @@ if (module.hot) {
     function registerInstance(domNode, flags, path, portSubscribes) {
       var id = getId();
 
-      const instance = {
+      var instance = {
         id: id,
         path: path,
         domNode: domNode,


### PR DESCRIPTION
If you run elm-hot-loader under safari, it will complain about the const,
since vanilla Safari does not support that yet. We don't really need it
so this change makes Safari happy.